### PR TITLE
Added kill ring buffer support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
-TARGET_DIR_PATH = ${OBSIDIAN_PLUGINS_DIR}/emacs-text-editor
+.DEFAULT_GOAL := build
+.PHONY: install build lint setup uninstall
+SHELL = bash
+INSTALL_DIR = ${OBSIDIAN_PLUGINS_DIR}/emacs-text-editor
 
-lint:
-	eslint main.ts
+setup:
+	npm install
+
+lint: setup
+	eslint --fix main.ts
 
 build: lint
 	npm run build
 
 install: build
-	mkdir -p ${TARGET_DIR_PATH}
-	cp main.js manifest.json ${TARGET_DIR_PATH}
+	[[ ! -z $$OBSIDIAN_PLUGINS_DIR ]] || (echo "OBSIDIAN_PLUGINS_DIR env var not set"; false)
+	[[ -d "${OBSIDIAN_PLUGINS_DIR}" ]] || (echo "OBSIDIAN_PLUGINS_DIR env var directory does not exit: ${OBSIDIAN_PLUGINS_DIR}")
+	[[ -d "${INSTALL_DIR}" ]] || mkdir -p ${INSTALL_DIR}
+	cp main.js manifest.json ${INSTALL_DIR}
 
 uninstall:
-	rm -rf ${TARGET_DIR_PATH}
+	rm -rf ${INSTALL_DIR}

--- a/main.ts
+++ b/main.ts
@@ -1,19 +1,12 @@
-import { Editor, EditorPosition, Plugin, MarkdownView } from "obsidian";
+import {Editor, EditorPosition, MarkdownView, Plugin} from "obsidian";
 
 enum Direction {
-	Forward,
-	Backward
+	Forward, Backward
 }
 
-const ExtendLastKillOnRepeatCommands = [
-	'kill-word',
-	'backward-kill-word',
-	'kill-line'
-]
+const ExtendLastKillOnRepeatCommands = ['kill-word', 'backward-kill-word', 'kill-line']
 
-const ExtendLastKillBackwardsOnRepeatCommands = [
-	'backwards-kill-word'
-]
+const ExtendLastKillBackwardsOnRepeatCommands = ['backwards-kill-word']
 
 export default class EmacsTextEditorPlugin extends Plugin {
 	// toggle to enable debug logging
@@ -37,6 +30,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'forward-char',
 			name: 'Forward char',
+			hotkeys: [{modifiers: ["Ctrl"], key: "f"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("forward-char")
 				this.withSelectionUpdate(editor, () => {
@@ -49,6 +43,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'backward-char',
 			name: 'Backward char',
+			hotkeys: [{modifiers: ["Ctrl"], key: "b"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("backward-char")
 				this.withSelectionUpdate(editor, () => {
@@ -60,6 +55,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'next-line',
 			name: 'Next line',
+			hotkeys: [{modifiers: ["Ctrl"], key: "n"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("next-line")
 				this.withSelectionUpdate(editor, () => {
@@ -71,6 +67,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'previous-line',
 			name: 'Previous line',
+			hotkeys: [{modifiers: ["Ctrl"], key: "p"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("previous-line")
 				this.withSelectionUpdate(editor, () => {
@@ -82,6 +79,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'forward-word',
 			name: 'Forward word',
+			hotkeys: [{modifiers: ["Alt"], key: "f"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("forward-word")
 				this.withSelectionUpdate(editor, () => {
@@ -93,6 +91,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'backward-word',
 			name: 'Backward word',
+			hotkeys: [{modifiers: ["Alt"], key: "b"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("backward-word")
 				this.withSelectionUpdate(editor, () => {
@@ -104,12 +103,13 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'move-end-of-line',
 			name: 'Move end of line',
+			hotkeys: [{modifiers: ["Ctrl"], key: "e"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("move-end-of-line")
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
 					const lineContent = editor.getLine(cursor.line)
-					editor.setCursor({ line: cursor.line, ch: lineContent.length })
+					editor.setCursor({line: cursor.line, ch: lineContent.length})
 				})
 			}
 		});
@@ -117,11 +117,12 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'move-beginning-of-line',
 			name: 'Move cursor to beginning of line',
+			hotkeys: [{modifiers: ["Ctrl"], key: "a"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("move-beginning-of-line")
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
-					editor.setCursor({ line: cursor.line, ch: 0 })
+					editor.setCursor({line: cursor.line, ch: 0})
 				})
 			}
 		});
@@ -129,6 +130,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'beginning-of-buffer',
 			name: 'Beginning of buffer',
+			hotkeys: [{modifiers: ["Alt", "Shift"], key: ","}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("beginning-of-buffer")
 				this.withSelectionUpdate(editor, () => {
@@ -140,6 +142,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'end-of-buffer',
 			name: 'End of buffer',
+			hotkeys: [{modifiers: ["Alt", "Shift"], key: "."}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("end-of-buffer")
 				this.withSelectionUpdate(editor, () => {
@@ -151,6 +154,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-line',
 			name: 'Kill line',
+			hotkeys: [{modifiers: ["Ctrl"], key: "k"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("kill-line")
 				await this.killLine(editor)
@@ -160,6 +164,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'delete-char',
 			name: 'Delete char',
+			hotkeys: [{modifiers: ["Ctrl"], key: "d"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("delete-char")
 				await this.withDelete(editor, () => {
@@ -171,6 +176,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-word',
 			name: 'Kill word',
+			hotkeys: [{modifiers: ["Alt"], key: "d"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("kill-word")
 				await this.withKill(editor, () => {
@@ -182,6 +188,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'backward-kill-word',
 			name: 'Backward kill word',
+			hotkeys: [{"modifiers": ["Alt"], key: "Backspace"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("backward-kill-word")
 				await this.withKill(editor, () => {
@@ -193,6 +200,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-ring-save',
 			name: 'Kill ring save',
+			hotkeys: [{"modifiers": ["Alt"], key: "w"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked('kill-ring-save')
 				if (!this.selectionIsActive()) {
@@ -206,6 +214,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-region',
 			name: 'Kill region',
+			hotkeys: [{modifiers: ["Ctrl"], key: "w"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked('kill-region')
 				await this.killRegion(editor)
@@ -215,6 +224,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'yank',
 			name: 'Yank',
+			hotkeys: [{modifiers: ["Ctrl"], key: "y"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked('yank')
 				await this.yank(editor)
@@ -225,6 +235,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: "yank-pop",
 			name: "Yank Pop",
+			hotkeys: [{modifiers: ["Alt"], key: "y"}],
 			editorCallback: async (editor, _) => {
 				this.commandInvoked("yank-pop")
 				await this.yankPop(editor)
@@ -234,6 +245,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'set-mark-command',
 			name: 'Set mark command',
+			hotkeys: [{modifiers: ["Ctrl"], key: " "}],
 			editorCallback: (editor, _) => {
 				this.commandInvoked("set-mark-command")
 				this.setMark(editor)
@@ -243,6 +255,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'keyboard-quit',
 			name: 'Keyboard-quit',
+			hotkeys: [{modifiers: ["Ctrl"], key: "g"}],
 			editorCallback: (editor, _) => {
 				this.commandInvoked("keyboard-quit")
 				this.keyboardQuit(editor)
@@ -252,6 +265,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'undo',
 			name: 'Undo',
+			hotkeys: [{modifiers: ["Ctrl", "Shift"], key: "-"}, {modifiers: ["Ctrl"], key: "/"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("undo")
 				editor.undo()
@@ -261,6 +275,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'redo',
 			name: 'Redo',
+			hotkeys: [{modifiers: ["Ctrl", "Shift", "Alt"], key: "-"}, {modifiers: ["Ctrl", "Shift"], key: "/"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("redo")
 				editor.redo()
@@ -270,6 +285,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'recenter-top-bottom',
 			name: 'Recenter',
+			hotkeys: [{modifiers: ["Ctrl"], key: "l"}],
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked("recenter-top-bottom")
 				this.recenterToBottom(editor)
@@ -279,6 +295,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'forward-paragraph',
 			name: 'Forward paragraph',
+			hotkeys: [{modifiers: ["Alt", "Shift"], key: "]"}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked('forward-paragraph')
 				this.withSelectionUpdate(editor, () => {
@@ -290,6 +307,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'backward-paragraph',
 			name: 'Backward paragraph',
+			hotkeys: [{modifiers: ["Alt", "Shift"], key: "["}],
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
 				this.commandInvoked('backward-paragraph')
 				this.withSelectionUpdate(editor, () => {
@@ -311,7 +329,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 	}
 
 	logDebug(text: string) {
-		if (! this.debugEnabled ) {
+		if (!this.debugEnabled) {
 			return
 		}
 		console.log("emacs-text-editor: " + text)
@@ -339,7 +357,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		const end = editor.getCursor()
 		this.logDebug("extending selection to cursor at " + JSON.stringify(end))
 		editor.setSelection(start, end)
-		this.logDebug("selection is now from " + JSON.stringify(start) +  " to " + JSON.stringify(end))
+		this.logDebug("selection is now from " + JSON.stringify(start) + " to " + JSON.stringify(end))
 		this.logDebug("selected text: " + editor.getSelection())
 	}
 
@@ -361,7 +379,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			const lastKill = this.killRing[this.yankIndex]
 			if (this.extendLastKillBackwards) {
 				text = text + lastKill
-			}  else {
+			} else {
 				text = lastKill + text
 			}
 		} else {
@@ -393,6 +411,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 	selectionIsActive(): boolean {
 		return (this.selectFrom !== undefined)
 	}
+
 	async withKill(editor: Editor, callback: () => void) {
 		this.withSelect(editor, callback)
 		await this.replaceSelectedText(editor, "", true)
@@ -403,7 +422,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			return;
 		}
 		this.logDebug("replacing selected text")
-		if (! text) {
+		if (!text) {
 			text = ""
 		}
 		if (save) {
@@ -427,6 +446,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.logDebug("selected text is now: " + editor.getSelection())
 
 	}
+
 	async killWord(editor: Editor) {
 		this.cancelSelect(editor);
 		await this.withKill(editor, () => {
@@ -526,8 +546,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 	recenterToBottom(editor: Editor) {
 		const cursor = editor.getCursor();
 		const range = {
-			from: {line: cursor.line, ch: cursor.ch},
-			to: {line: cursor.line, ch: cursor.ch}
+			from: {line: cursor.line, ch: cursor.ch}, to: {line: cursor.line, ch: cursor.ch}
 		};
 		editor.scrollIntoView(range, true);
 	}
@@ -538,8 +557,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		const maxOffset = value.length;
 		const currentOffset = editor.posToOffset(cursor);
 
-		if ((direction === Direction.Forward && currentOffset >= maxOffset) ||
-			(direction === Direction.Backward && currentOffset === 0)) {
+		if ((direction === Direction.Forward && currentOffset >= maxOffset) || (direction === Direction.Backward && currentOffset === 0)) {
 			return;
 		}
 
@@ -562,8 +580,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			if (foundText && isNewLine(i, direction)) {
 				if (foundFirstBreak) {
 					nextParagraphOffset = direction === Direction.Forward ? i : i + 1;
-					if ((direction === Direction.Forward && value[i] === "\r") ||
-						(direction === Direction.Backward && i > 0 && value[i - 1] === "\r")) {
+					if ((direction === Direction.Forward && value[i] === "\r") || (direction === Direction.Backward && i > 0 && value[i - 1] === "\r")) {
 						nextParagraphOffset += direction === Direction.Forward ? 1 : -1;
 					}
 					break;

--- a/main.ts
+++ b/main.ts
@@ -5,19 +5,42 @@ enum Direction {
 	Backward
 }
 
-export default class EmacsTextEditorPlugin extends Plugin {
+const ExtendLastKillOnRepeatCommands = [
+	'kill-word',
+	'backward-kill-word',
+	'kill-line'
+]
 
+const ExtendLastKillBackwardsOnRepeatCommands = [
+	'backwards-kill-word'
+]
+
+export default class EmacsTextEditorPlugin extends Plugin {
+	// toggle to enable debug logging
+	debugEnabled = false
+	extendLastKill = false
+	extendLastKillBackwards = false
+	killRing: string[] = []
+	killRingEndIndex = -1
+	killRingMaxSize = 120 // Same default size as emacs
+	lastCommandInvoked?: string = undefined
+	yankEnd?: EditorPosition = undefined
 	// TODO: Consider possibility migrate to native selection mechanism
 	selectFrom?: EditorPosition = undefined
+	yankIndex = -1
+	yankPopIndex = -1
+	yankStart?: EditorPosition = undefined
 
 	onload() {
+		this.killRing = new Array<string>(this.killRingMaxSize)
 		console.log('loading plugin: Emacs text editor');
-
 		this.addCommand({
 			id: 'forward-char',
 			name: 'Forward char',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("forward-char")
 				this.withSelectionUpdate(editor, () => {
+					this.cancelYankPop();
 					editor.exec("goRight")
 				})
 			}
@@ -27,6 +50,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'backward-char',
 			name: 'Backward char',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("backward-char")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goLeft")
 				})
@@ -37,6 +61,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'next-line',
 			name: 'Next line',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("next-line")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goDown")
 				})
@@ -47,6 +72,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'previous-line',
 			name: 'Previous line',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("previous-line")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goUp")
 				})
@@ -57,6 +83,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'forward-word',
 			name: 'Forward word',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("forward-word")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goWordRight")
 				})
@@ -67,6 +94,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'backward-word',
 			name: 'Backward word',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("backward-word")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goWordLeft")
 				})
@@ -77,6 +105,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'move-end-of-line',
 			name: 'Move end of line',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("move-end-of-line")
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
 					const lineContent = editor.getLine(cursor.line)
@@ -89,6 +118,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'move-beginning-of-line',
 			name: 'Move cursor to beginning of line',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("move-beginning-of-line")
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
 					editor.setCursor({ line: cursor.line, ch: 0 })
@@ -100,6 +130,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'beginning-of-buffer',
 			name: 'Beginning of buffer',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("beginning-of-buffer")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goStart")
 				})
@@ -110,6 +141,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'end-of-buffer',
 			name: 'End of buffer',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("end-of-buffer")
 				this.withSelectionUpdate(editor, () => {
 					editor.exec("goEnd")
 				})
@@ -119,27 +151,18 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-line',
 			name: 'Kill line',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				this.disableSelection(editor)
-
-				const cursor = editor.getCursor()
-				const lineContent = editor.getLine(cursor.line)
-				if (lineContent === "") {
-					editor.exec("deleteLine")
-				} else {
-					editor.setLine(cursor.line, lineContent.substring(0, cursor.ch))
-					editor.setCursor(cursor)
-				}
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("kill-line")
+				await this.killLine(editor)
 			}
 		});
 
 		this.addCommand({
 			id: 'delete-char',
 			name: 'Delete char',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				this.disableSelection(editor)
-
-				this.withDeleteInText(editor, () => {
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("delete-char")
+				await this.withDelete(editor, () => {
 					editor.exec("goRight")
 				})
 			}
@@ -148,23 +171,21 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-word',
 			name: 'Kill word',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				this.disableSelection(editor)
-
-				this.withDeleteInText(editor, () => {
-					editor.exec("goWordRight")
-				})
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("kill-word")
+				await this.withKill(editor, () => {
+					editor.exec("goWordRight");
+				});
 			}
 		});
 
 		this.addCommand({
 			id: 'backward-kill-word',
 			name: 'Backward kill word',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				this.disableSelection(editor)
-
-				this.withDeleteInText(editor, () => {
-					editor.exec("goWordLeft")
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("backward-kill-word")
+				await this.withKill(editor, () => {
+					editor.exec("goWordLeft");
 				})
 			}
 		});
@@ -172,29 +193,22 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		this.addCommand({
 			id: 'kill-ring-save',
 			name: 'Kill ring save',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				if (this.selectFrom === undefined) {
-					return
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked('kill-ring-save')
+				if (!this.selectionIsActive()) {
+					return;
 				}
-
-				navigator.clipboard.writeText(editor.getSelection())
-
-				this.disableSelection(editor)
+				await this.killRingSave(editor.getSelection());
+				this.cancelSelect(editor);
 			}
 		});
 
 		this.addCommand({
 			id: 'kill-region',
 			name: 'Kill region',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				if (this.selectFrom === undefined) {
-					return
-				}
-
-				navigator.clipboard.writeText(editor.getSelection())
-				editor.replaceSelection("")
-
-				this.disableSelection(editor)
+			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked('kill-region')
+				await this.killRegion(editor)
 			}
 		});
 
@@ -202,37 +216,36 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'yank',
 			name: 'Yank',
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
-				const clipboardContent = await navigator.clipboard.readText()
-				const cursor = editor.getCursor()
+				this.commandInvoked('yank')
+				await this.yank(editor)
+			}
+		});
 
-				if (this.selectFrom === undefined) {
-					editor.replaceRange(clipboardContent, cursor)
-				} else {
-					editor.replaceSelection(clipboardContent)
-					this.disableSelection(editor)
-				}
 
-				editor.setCursor(cursor.line, cursor.ch + clipboardContent.length)
+		this.addCommand({
+			id: "yank-pop",
+			name: "Yank Pop",
+			editorCallback: async (editor, _) => {
+				this.commandInvoked("yank-pop")
+				await this.yankPop(editor)
 			}
 		});
 
 		this.addCommand({
 			id: 'set-mark-command',
 			name: 'Set mark command',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				if (this.selectFrom === undefined) {
-					this.selectFrom = editor.getCursor()
-				} else {
-					this.disableSelection(editor)
-				}
+			editorCallback: (editor, _) => {
+				this.commandInvoked("set-mark-command")
+				this.setMark(editor)
 			}
 		});
 
 		this.addCommand({
 			id: 'keyboard-quit',
 			name: 'Keyboard-quit',
-			editorCallback: (editor: Editor, _: MarkdownView) => {
-				this.disableSelection(editor)
+			editorCallback: (editor, _) => {
+				this.commandInvoked("keyboard-quit")
+				this.keyboardQuit(editor)
 			}
 		});
 
@@ -240,6 +253,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'undo',
 			name: 'Undo',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("undo")
 				editor.undo()
 			}
 		});
@@ -248,6 +262,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'redo',
 			name: 'Redo',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked("redo")
 				editor.redo()
 			}
 		});
@@ -256,12 +271,8 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'recenter-top-bottom',
 			name: 'Recenter',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
-				const cursor = editor.getCursor()
-				const range = {
-					from: { line: cursor.line, ch: cursor.ch },
-					to: { line: cursor.line, ch: cursor.ch }
-				}
-				editor.scrollIntoView(range, true)
+				this.commandInvoked("recenter-top-bottom")
+				this.recenterToBottom(editor)
 			}
 		});
 
@@ -269,6 +280,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'forward-paragraph',
 			name: 'Forward paragraph',
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked('forward-paragraph')
 				this.withSelectionUpdate(editor, () => {
 					this.moveToNextParagraph(editor, Direction.Forward)
 				})
@@ -279,21 +291,34 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			id: 'backward-paragraph',
 			name: 'Backward paragraph',
 			editorCallback: async (editor: Editor, _: MarkdownView) => {
+				this.commandInvoked('backward-paragraph')
 				this.withSelectionUpdate(editor, () => {
 					this.moveToNextParagraph(editor, Direction.Backward)
 				})
 			}
 		});
+	}
 
+	commandInvoked(id: string) {
+		this.logDebug("command invoked: " + id)
+		if (id !== "yank-pop") {
+			this.cancelYankPop()
+		}
+		const isRepeat = this.lastCommandInvoked === id
+		this.extendLastKill = isRepeat && ExtendLastKillOnRepeatCommands.includes(id)
+		this.extendLastKillBackwards = isRepeat && ExtendLastKillBackwardsOnRepeatCommands.includes(id)
+		this.lastCommandInvoked = id
+	}
+
+	logDebug(text: string) {
+		if (! this.debugEnabled ) {
+			return
+		}
+		console.log("emacs-text-editor: " + text)
 	}
 
 	onunload() {
 		console.log('unloading plugin: Emacs text editor');
-	}
-
-	disableSelection(editor: Editor) {
-		editor.setSelection(editor.getCursor(), editor.getCursor())
-		this.selectFrom = undefined
 	}
 
 	withSelectionUpdate(editor: Editor, callback: () => void) {
@@ -303,26 +328,208 @@ export default class EmacsTextEditorPlugin extends Plugin {
 
 		callback()
 
-		this.updateSelectionIsNeed(editor)
+		this.extendSelection(editor)
 	}
 
-	updateSelectionIsNeed(editor: Editor) {
+	extendSelection(editor: Editor) {
 		if (this.selectFrom === undefined) {
 			return
 		}
-
-		editor.setSelection(this.selectFrom, editor.getCursor())
+		const start = this.selectFrom
+		const end = editor.getCursor()
+		this.logDebug("extending selection to cursor at " + JSON.stringify(end))
+		editor.setSelection(start, end)
+		this.logDebug("selection is now from " + JSON.stringify(start) +  " to " + JSON.stringify(end))
+		this.logDebug("selected text: " + editor.getSelection())
 	}
 
-	withDeleteInText(editor: Editor, callback: () => void) {
+	async withDelete(editor: Editor, callback: () => void) {
 		const cursorBefore = editor.getCursor()
-
 		callback()
-
 		const cursorAfter = editor.getCursor()
-
 		editor.setSelection(cursorBefore, cursorAfter)
+		this.logDebug("set selection from " + cursorBefore + " to " + cursorAfter + ", selected text: " + editor.getSelection())
+		this.logDebug("seplacing selection with empty string")
 		editor.replaceSelection("")
+		this.cancelSelect(editor)
+	}
+
+
+	async killRingSave(text: string) {
+		if (this.extendLastKill && this.killRing[this.yankIndex]) {
+			this.logDebug("extending last kill")
+			const lastKill = this.killRing[this.yankIndex]
+			if (this.extendLastKillBackwards) {
+				text = text + lastKill
+			}  else {
+				text = lastKill + text
+			}
+		} else {
+			this.yankIndex++
+			if (this.yankIndex >= this.killRingMaxSize) {
+				this.yankIndex = 0
+			}
+			if (this.yankIndex > this.killRingEndIndex) {
+				this.killRingEndIndex = this.yankIndex
+			}
+		}
+		this.killRing[this.yankIndex] = text
+		this.logDebug("kill ring index " + this.yankIndex + " text now : " + text)
+		const clipboardText = await navigator.clipboard.readText()
+		if (clipboardText === text) {
+			return;
+		}
+		await navigator.clipboard.writeText(text);
+		this.logDebug("wrote text to navigator clipboard: " + text)
+
+	}
+
+	cancelSelect(editor: Editor) {
+		this.logDebug("clearing selection")
+		editor.setSelection(editor.getCursor(), editor.getCursor());
+		this.selectFrom = undefined;
+	}
+
+	selectionIsActive(): boolean {
+		return (this.selectFrom !== undefined)
+	}
+	async withKill(editor: Editor, callback: () => void) {
+		this.withSelect(editor, callback)
+		await this.replaceSelectedText(editor, "", true)
+	}
+
+	async replaceSelectedText(editor: Editor, text = "", save = true) {
+		if (!this.selectionIsActive()) {
+			return;
+		}
+		this.logDebug("replacing selected text")
+		if (! text) {
+			text = ""
+		}
+		if (save) {
+			const selectedText = editor.getSelection()
+			this.logDebug("saving selected text to kill ring: " + selectedText)
+			await this.killRingSave(selectedText)
+		}
+		editor.replaceSelection(text);
+		this.logDebug("replaced selected text with '" + text + "'")
+		this.cancelSelect(editor);
+	}
+
+	withSelect(editor: Editor, callback: () => void) {
+		this.cancelSelect(editor);
+		const start = editor.getCursor();
+		this.selectFrom = start
+		callback();
+		const end = editor.getCursor();
+		this.logDebug("selecting text from " + JSON.stringify(start) + " to " + JSON.stringify(end))
+		editor.setSelection(start, end);
+		this.logDebug("selected text is now: " + editor.getSelection())
+
+	}
+	async killWord(editor: Editor) {
+		this.cancelSelect(editor);
+		await this.withKill(editor, () => {
+			editor.exec("goWordRight");
+		});
+	}
+
+	async killLine(editor: Editor) {
+		const cursor = editor.getCursor();
+		const line = editor.getLine(cursor.line);
+		this.logDebug("kill-line - line is '" + line + "'")
+		if (line === '') {
+			await this.withKill(editor, () => {
+				editor.exec("goRight")
+			})
+			return
+		}
+		this.logDebug("kill-line - cursor is " + JSON.stringify(cursor))
+		const textToBeRetained = line.slice(0, cursor.ch);
+		const textToBeCut = line.slice(cursor.ch);
+		await this.killRingSave(textToBeCut)
+		this.logDebug("kill-line - setting line " + cursor.line + " to '" + textToBeRetained + "'")
+		editor.setLine(cursor.line, textToBeRetained);
+		editor.setCursor(cursor, cursor.ch);
+	}
+
+	async killRegion(editor: Editor) {
+		await this.replaceSelectedText(editor, "", true)
+	}
+
+	async yank(editor: Editor) {
+		this.logDebug("started yank")
+		this.cancelYankPop();
+		const clipboardText = await navigator.clipboard.readText();
+		const yankText = this.killRing[this.yankIndex]
+		if (yankText !== clipboardText) {
+			await this.killRingSave(clipboardText)
+		}
+		const position = editor.getCursor();
+		if (!this.selectionIsActive()) {
+			this.logDebug("inserting text at position " + position + ": " + clipboardText)
+			editor.replaceRange(clipboardText, position);
+		} else {
+			this.logDebug("replacing selection with: " + clipboardText)
+			editor.replaceSelection(clipboardText);
+			this.cancelSelect(editor);
+		}
+		this.yankStart = position;
+		editor.setCursor(this.yankStart.line, this.yankStart.ch + clipboardText.length);
+		this.yankEnd = editor.getCursor()
+		this.yankPopIndex = this.yankIndex - 1;
+		this.logDebug("yanked '" + yankText + "'")
+	}
+
+	cancelYankPop() {
+		this.yankPopIndex = this.yankIndex;
+		this.yankStart = undefined;
+		this.yankEnd = undefined;
+		this.logDebug("yank pop stopped")
+	}
+
+	async yankPop(editor: Editor) {
+		this.logDebug("yank pop started")
+		if (this.yankStart === undefined || this.yankEnd === undefined || this.yankIndex < 0) {
+			this.logDebug("can't yank pop")
+			return;
+		}
+		if (this.yankPopIndex < 0) {
+			this.yankPopIndex = this.killRingEndIndex
+			console.log("yank pop index less than zero, setting to kill ring end index " + this.yankPopIndex)
+		}
+		const yankPopText = this.killRing[this.yankPopIndex];
+		console.log("yank pop text: " + yankPopText)
+		this.cancelSelect(editor);
+		editor.setSelection(this.yankStart, this.yankEnd)
+		editor.replaceSelection(yankPopText);
+		editor.setCursor(this.yankStart.line, this.yankStart.ch + yankPopText.length);
+		this.yankEnd = editor.getCursor()
+		this.yankPopIndex--;
+		this.logDebug("yank poppped '" + yankPopText + "'")
+	}
+
+	setMark(editor: Editor) {
+		/*  start new selection from cursor if already started */
+		if (this.selectionIsActive()) {
+			this.cancelSelect(editor);
+		}
+		this.selectFrom = editor.getCursor();
+		this.logDebug("selection start is now " + this.selectFrom)
+	}
+
+	keyboardQuit(editor: Editor) {
+		this.cancelYankPop();
+		this.cancelSelect(editor)
+	}
+
+	recenterToBottom(editor: Editor) {
+		const cursor = editor.getCursor();
+		const range = {
+			from: {line: cursor.line, ch: cursor.ch},
+			to: {line: cursor.line, ch: cursor.ch}
+		};
+		editor.scrollIntoView(range, true);
 	}
 
 	moveToNextParagraph(editor: Editor, direction: Direction) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
+	"name": "emacs-text-editor",
+	"version": "0.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-sample-plugin",
-			"version": "1.0.0",
-			"license": "MIT",
+			"name": "emacs-text-editor",
+			"version": "0.3.1",
+			"license": "GPL-3.0",
 			"devDependencies": {
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",


### PR DESCRIPTION
## Added kill ring buffer support
 - kill-line, kill-word, backward-kill-word, yank and yank-pop now actually work like emacs (and readline, for that matter).                                                                                                          
 - Default kill ring size is 120 (same as emacs)                                                               
 - Repeat invocations of kill-line, kill-word, and backward-kill-word will extend the last saved kill, just like they do in emacs .

## Logging changes
                                                                                                               
- Added support for debug logging, disabled by default.                                                        
                                                                                                               
## Makefile changes
                                                                                                               
 - Set default Makefile target to be 'build'                                                                   
 - Added 'setup' target that runs 'npm install'                                                                
 - Target dependency chain now install <- build <- lint <- setup
 - Fixed 'install' target to check if OBSIDIAN_PLUGINS_DIR is not set and not try and install into '/emacs-text-edit'
 - '--fix' flag added to 'eslint' invocation in 'lint' target                                                                  
