### PR TITLE
Added another behavior of beginning-of-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ make uninstall
 | Alt + w                 | Kill ring save             | Copy a selected region    |
 | Alt + d                 | Kill word                  | Delete chars until end of a word |
 | Ctrl + a                | Move beginning of line     | Move cursor to beginning of line |
+|                         | Move cursor after heading markdown of beginning of line (like a HOME key) | Move cursor to  *head of text*, considering indentation, lists, task lists |
 | Ctrl + e                | Move end of line           | Move cursor to end of line |
 | Ctrl + n                | Next line                  | Move cursor to next line |
 | Ctrl + p                | Previous line              | Move cursor to previous line |

--- a/main.ts
+++ b/main.ts
@@ -101,14 +101,17 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
-					const regex = /^\s*(-\s(\[.\]\s)?)?/
-					const result = regex.exec(editor.getLine(cursor.line))
-					if (result !== undefined) {
-						if (result[0].length < cursor.ch) {
-							editor.setCursor({ line: cursor.line, ch: result[0].length })
-						} else {
-							editor.setCursor({ line: cursor.line, ch: 0 })
-						}
+					if (cursor.ch == 0) return;
+
+					const line = editor.getLine(cursor.line)
+					let result = line.match(/^#{1,6}\s/)
+					if (result === null) {
+						result = line.match(/^\s*(-\s(\[.\]\s)?)?/)
+					}
+					if (result !== null && result[0].length < cursor.ch) {
+						editor.setCursor({ line: cursor.line, ch: result[0].length })
+					} else {
+						editor.setCursor({ line: cursor.line, ch: 0 })
 					}
 				})
 			}

--- a/main.ts
+++ b/main.ts
@@ -96,6 +96,34 @@ export default class EmacsTextEditorPlugin extends Plugin {
 		});
 
 		this.addCommand({
+			id: 'move-beginning-of-line-like-homekey',
+			name: 'Move cursor to beginning of line (like a HOME key)',
+			editorCallback: (editor: Editor, _: MarkdownView) => {
+				this.withSelectionUpdate(editor, () => {
+					const cursor = editor.getCursor()
+					const line = editor.getLine(cursor.line)
+					const ptnChkbx = /^\s*-\s\[.\]\s/
+					const ptnList = /^\s*-\s/
+					const resultChkbx = line.match(ptnChkbx)
+					if (resultChkbx) {
+						if (resultChkbx[0].length < cursor.ch) {
+							editor.setCursor({ line: cursor.line, ch: resultChkbx[0].length })
+						} else {
+							editor.setCursor({ line: cursor.line, ch: 0 })
+						}
+					} else {
+						const resultList = line.match(ptnList)
+						if (resultList && resultList[0].length < cursor.ch) {
+							editor.setCursor({ line: cursor.line, ch: resultList[0].length })
+						} else {
+							editor.setCursor({ line: cursor.line, ch: 0 })
+						}
+					}
+				})
+			}
+		});
+
+		this.addCommand({
 			id: 'beginning-of-buffer',
 			name: 'Beginning of buffer',
 			editorCallback: (editor: Editor, _: MarkdownView) => {

--- a/main.ts
+++ b/main.ts
@@ -97,7 +97,7 @@ export default class EmacsTextEditorPlugin extends Plugin {
 
 		this.addCommand({
 			id: 'move-beginning-of-line-like-homekey',
-			name: 'Move cursor to beginning of line (like a HOME key)',
+			name: 'Move cursor after heading markdown of beginning of line (like a HOME key)',
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
@@ -105,6 +105,9 @@ export default class EmacsTextEditorPlugin extends Plugin {
 
 					const line = editor.getLine(cursor.line)
 					let result = line.match(/^#{1,6}\s/)
+					if (result === null) {
+						result = line.match(/^\s*\d+\.\s/)
+					}
 					if (result === null) {
 						result = line.match(/^\s*(-\s(\[.\]\s)?)?/)
 					}

--- a/main.ts
+++ b/main.ts
@@ -101,20 +101,11 @@ export default class EmacsTextEditorPlugin extends Plugin {
 			editorCallback: (editor: Editor, _: MarkdownView) => {
 				this.withSelectionUpdate(editor, () => {
 					const cursor = editor.getCursor()
-					const line = editor.getLine(cursor.line)
-					const ptnChkbx = /^\s*-\s\[.\]\s/
-					const ptnList = /^\s*-\s/
-					const resultChkbx = line.match(ptnChkbx)
-					if (resultChkbx) {
-						if (resultChkbx[0].length < cursor.ch) {
-							editor.setCursor({ line: cursor.line, ch: resultChkbx[0].length })
-						} else {
-							editor.setCursor({ line: cursor.line, ch: 0 })
-						}
-					} else {
-						const resultList = line.match(ptnList)
-						if (resultList && resultList[0].length < cursor.ch) {
-							editor.setCursor({ line: cursor.line, ch: resultList[0].length })
+					const regex = /^\s*(-\s(\[.\]\s)?)?/
+					const result = regex.exec(editor.getLine(cursor.line))
+					if (result !== undefined) {
+						if (result[0].length < cursor.ch) {
+							editor.setCursor({ line: cursor.line, ch: result[0].length })
 						} else {
 							editor.setCursor({ line: cursor.line, ch: 0 })
 						}


### PR DESCRIPTION
An action "beginning-of-line" is just set cursor position to `ch: 0` ,
But sometime I want to move cursor to *head of text*, considering indentation, lists, task lists, and so on.

This PR provides another behavior of beginning-of-line, similer to press HOME key.
- move cursor to between indentation and text.
- move cursor between list (-), task list (- [ ]), enumulation characters (1. ) and text.
- move cursor between heading characters (#) and text.

When pipe character "|" is cursor:
```
     some indented text|
(exec command beginning-of-line-as-homekey)
    |some indented text
(exec again)
|    some indented text

    - some list item|
    - |some list item
|   - some list item

    - [ ] some task list item|
    - [ ] |some task list item
|   - [ ] some task list item

    1. some numbered list item|
    1. |some numbered list item
|   1. some numbered list item

## some heading text|
## |some heading text
|## some heading text
```

How do you feel about this added feature?
or shuld I split another plugin?